### PR TITLE
Fix the Rakefile to catch LoadError on require and skip tasks which require packages not present by `rake install`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,20 +1,33 @@
 require 'bundler/gem_tasks'
-require 'rake/testtask'
-require 'rubocop/rake_task'
-require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
-
-desc 'Run RuboCop on the lib directory'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.patterns = ['lib/**/*.rb']
-  task.fail_on_error = false
+begin
+  require 'rake/testtask'
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  desc 'Runs code coverage'
+  task :rcov do
+    ENV['COVERAGE'] = 'true'
+    Rake::Task[:spec].invoke
+  end
+rescue LoadError
+  puts "RSpec is not installed, please run `bundle install` in order to execute unit test tasks"
 end
 
-task default: [:rubocop, :spec]
+begin
+  require 'rubocop/rake_task'
+  desc 'Run RuboCop on the lib directory'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.patterns = ['lib/**/*.rb']
+    task.fail_on_error = false
+  end
+rescue LoadError
+  puts "RuboCop is not installed, please run `bundle install` in order to execute RuboCop tasks"
+end
 
-desc 'Runs code coverage'
-task :rcov do
-  ENV['COVERAGE'] = 'true'
-  Rake::Task[:spec].invoke
+if defined?(RuboCop::RakeTask)
+  task default: [:rubocop, :spec]
+else
+  task :default do
+    puts 'The default task runs RSpec unit tests and RuboCop if they are installed.  Otherwise it prints this message.'
+  end
 end


### PR DESCRIPTION
This partially fixes the issue in Lyle-Tafoya/Steam-Categorizer#23

The original problem in that issue I believe was caused by the person not having a correctly set-up Ruby environment.  There was somebody else that pointed out my earlier RuboCop addition caused `rake install` to break.  This was caused by the `require` statements at the top of the `Rakefile` expecting RSpec and RuboCop to be installed, which they wouldn't be unless `bundle install` had been run.  This changeset fixes it so that `rake install` works normally, and tasks for development that run RSpec and RuboCop are only available if both are installed.

Sorry about that, I didn't think about my environment locally not being directly portable in this case.